### PR TITLE
re-do the change to fix helper_inet_t to always print out the rpcprog na...

### DIFF
--- a/libpub/pslave.h
+++ b/libpub/pslave.h
@@ -260,10 +260,17 @@ private:
 class helper_inet_t : public helper_t {
 public:
   helper_inet_t (const rpc_program &rp, const str &hn, u_int p, u_int o = 0) 
-    : helper_t (rp, o), hostname (hn), port (p) {}
-  virtual str getname () const { return (strbuf (hostname) << ":" << port); }
+    : helper_t (rp, o), hostname (hn), port (p) {
+        if (!hostname.len()) {
+            fatal << "ERROR: Empty hostname for connecting to "
+                  << rpcprog.name << "\n";
+        }
+    }
+  virtual str getname () const {
+      return (strbuf (hostname) << ":" << port << ":" << rpcprog.name);
+  }
   void call (u_int32_t procno, const void *in, void *out, aclnt_cb cb,
-	     time_t duration = 600) {
+          time_t duration = 600) {
     helper_t::call(procno, in, out, cb, duration);
   }
 

--- a/libpub/pub3obj.C
+++ b/libpub/pub3obj.C
@@ -126,7 +126,7 @@ namespace pub3 {
       expr_dict_t::const_iterator_t it (*d);
       const str *key;
       while ((key = it.next ())) {
-	ret->push_back (*key);
+          ret->push_back (*key);
       }
     }
     return ret;

--- a/libweb/web.h
+++ b/libweb/web.h
@@ -35,7 +35,7 @@
 class okdate_t {
 public:
   okdate_t (const x_okdate_t &x) : err (false), dt_tm (0), stm_set (false),
-				   time_t_set (false)
+    time_t_set (false)
   { set (x); }
   virtual ~okdate_t () {}
 


### PR DESCRIPTION
This is basically the same as 12c843f49c71d5084ef65609cb57ae674cbef4c0, which got clobbered when we had to roll back.
