### PR TITLE
Parse reverse proxy headers.

### DIFF
--- a/libaok/ok.T
+++ b/libaok/ok.T
@@ -58,6 +58,18 @@ init_syscall_stats ()
 
 //-----------------------------------------------------------------------
 
+bool is_internal(const ptr<const ahttpcon> &con) {
+  static const in_addr_t localhost_ip = inet_addr("127.0.0.1");
+  if (!con)
+    return false;
+  const sockaddr_in *in_addr = con->get_sin();
+  if (!in_addr)
+    return false;
+  return con->get_sin()->sin_addr.s_addr == localhost_ip;
+}
+
+//-----------------------------------------------------------------------
+
 void
 ok_httpsrv_t::malloc_init () {}
 
@@ -988,6 +1000,48 @@ okclnt2_t::set_keepalive_attributes (http_resp_attributes_t *hra)
       hra->set_connection (tmp);
     }
   }
+}
+
+
+//-----------------------------------------------------------------------
+
+bool okclnt_base_t::is_ssl() const {
+  return _demux_data && _demux_data->ssl();
+}
+
+//-----------------------------------------------------------------------
+
+bool okclnt2_t::is_ssl() const {
+  str proxy_info;
+  if (is_internal(client_con()) && (proxy_info = (*this)["x-forwarded-proto"])) {
+    return proxy_info == "https";
+  }
+  return _demux_data && _demux_data->ssl();
+}
+
+//-----------------------------------------------------------------------
+
+uint32_t okclnt2_t::get_ip() const {
+  str proxy_info;
+  if (is_internal(client_con()) && (proxy_info = (*this)["x-real-ip"])) {
+    struct sockaddr_in addr;
+    if (inet_aton(proxy_info.cstr(), &addr.sin_addr)) {
+      return addr.sin_addr.s_addr;
+    }
+    warn <<  __FILE__ "[" << __LINE__ <<  "] in " << __func__ << ": "
+      "Could not read proxy info properly." << proxy_info << "\n";
+  }
+  return client_con()->get_sin()->sin_addr.s_addr;
+}
+
+//-----------------------------------------------------------------------
+
+str okclnt2_t::get_ip_str() const {
+  str proxy_info;
+  if (is_internal(client_con()) && (proxy_info = (*this)["x-real-ip"])) {
+    return proxy_info;
+  }
+  return inet_ntoa(client_con()->get_sin()->sin_addr);
 }
 
 //-----------------------------------------------------------------------

--- a/libaok/ok.h
+++ b/libaok/ok.h
@@ -97,6 +97,10 @@ private:
 
 //-----------------------------------------------------------------------
 
+bool is_internal(const ptr<const ahttpcon>&);
+
+//-----------------------------------------------------------------------
+
 class demux_data_t {
 private:
   static struct timespec timespec_null;
@@ -569,10 +573,12 @@ public:
 
   void set_hdr_field (const str &k, const str &v);
 
-  void set_demux_data (ptr<demux_data_t> d) { _demux_data = d; }
-  bool is_ssl () const { return _demux_data && _demux_data->ssl (); }
-  str ssl_cipher () const;
-  int get_reqno () const;
+  void set_demux_data(ptr<demux_data_t> d) { _demux_data = d; }
+
+  virtual bool is_ssl() const;
+
+  str ssl_cipher() const;
+  int get_reqno() const;
 
   virtual ptr<pub3::ok_iface_t> pub3 () ;
   virtual ptr<pub3::ok_iface_t> pub3_local ();
@@ -670,11 +676,15 @@ public:
   okclnt2_t (ptr<ahttpcon> x, oksrvc_t *c, u_int to = 0) :
     okclnt_t (x, c, to) {}
 
-  void serve () { serve_T (); }
-  void process () {}
-  virtual void process (proc_ev_t ev) = 0;
-  void send_complete () {}
-  void serve_complete () { delete this; }
+  bool is_ssl() const override;
+  uint32_t get_ip() const;
+  str get_ip_str() const;
+
+  void serve() { serve_T(); }
+  void process() {}
+  virtual void process(proc_ev_t ev) = 0;
+  void send_complete() {}
+  void serve_complete() { delete this; }
 
   // okclnt2_t allows use of keepalive connections, but only
   // if this flag is toggled to true...


### PR DESCRIPTION
Assumes the following config in nginx:

```
            proxy_set_header  X-Real-IP $remote_addr;
            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header  X-Forwarded-Proto $scheme;
            proxy_set_header  Host $http_host;
            proxy_pass_header Server;
            proxy_pass_header Host;
```
