### PR TITLE
okd: Don't use peek to route requests since, on Linux, it may not expose all available data

### DIFF
--- a/libaok/ok.h
+++ b/libaok/ok.h
@@ -177,7 +177,7 @@ public:
     memcpy (x->sin.base (), (void *)sin, sizeof (*sin));
     _demux_data->to_xdr (x);
     x->reqno = _con->get_reqno ();
-    if (!_con->do_peek()) { _con->collect_scraps (x->scraps); }
+    _con->collect_scraps (x->scraps);
   }
 
 private:

--- a/okd/child.T
+++ b/okd/child.T
@@ -403,6 +403,8 @@ okch_t::send_con_to_service (ahttpcon_wrapper_t<ahttpcon_clone> acw, evv_t ev)
     acw.demux_data ()->set_forward_time ();
     acw.to_xdr (&arg);
 
+    arg.scraps = acw.con()->request_bytes;
+
     // Take the FD away from the ahttpcon; is OURS now.
     fd = xc->takefd ();
 


### PR DESCRIPTION
okd used the MSG_PEEK flag to look at the data available on a socket
without consuming it. If it wasn't enough (i.e. the whole URL hadn't
come through yet) it waited and peeked again later.

On FreeBSD, this works properly with both IP (AF_INET) and local
(AF_UNIX) sockets. On Linux, it will only ever return the first unread
message sent to a local socket. When an SSL connection is proxied
through okssld, okd's peeking at a local socket and the difference
becomes a problem: it might only ever get part of a request line.

There's an open bug against the Linux kernel to make it act like FreeBSD
in this case, but POSIX doesn't require it.

https://bugzilla.kernel.org/show_bug.cgi?id=12323

This change makes okd read normally from the socket and use the `scraps`
field to pass the read data to the websrv.
