### PR TITLE
Improve error reporting of timeouts

### DIFF
--- a/ezdb/libezdb/serve.C
+++ b/ezdb/libezdb/serve.C
@@ -229,7 +229,8 @@ namespace ezdb {
     time_t n = sfs_get_timenow ();
     while ((r = _q.first) && (n - r->_accessed > _timeout)) {
       str q = r->dump ();
-      warn << "Timing out stale query " << q << "\n";
+      warn << "Timing out stale query after " << (n - r->_accessed) << "s: " 
+           << " (timeout = " << _timeout << "s): " << q << "\n";
       remove (r);
     }
   }


### PR DESCRIPTION
I think this will be an improvement anyway, but the immediate use is for me to see what's going on with the stale queries from autombf.  I'm seeing them marked as stale in the logs after only a couple seconds after they are submitted to ezdb, and ezdb removes them from the queue before it ever submits them to the database.  The timeout is supposed to be set to 120 seconds, so I don't know why it is timing out after just a few seconds.
