### PR TITLE
Handle UTF-8 keys in jsonrpc.py

### DIFF
--- a/py/jsonrpc.py
+++ b/py/jsonrpc.py
@@ -279,6 +279,7 @@ class JsonWrapDict (dict):
     def __init__ (self, d):
         dict.__init__ (self, d)
         for (k,v) in d.items ():
+            k = k.encode("utf8")
             v = JsonWrap.alloc (v)
             self[k] = v
             setattr (self, k, v)


### PR DESCRIPTION
JsonWrapDict will blow up (in python 2) if handed a utf8 dict key. This patch fixes that.
