### PR TITLE
Check for request line too-big-ness later, fix spurious 414s

### DIFF
--- a/libahttp/ahttp.C
+++ b/libahttp/ahttp.C
@@ -522,11 +522,6 @@ ahttpcon_clone::declone ()
 str
 ahttpcon_clone::delimit (int *delimit_status)
 {
-  if (request_bytes.size() > maxline) {
-      *delimit_status = HTTP_URI_TOO_BIG;
-      return NULL;
-  }
-
   int delimit_state = 0;
   const char *delimit_start = nullptr;
 
@@ -559,6 +554,11 @@ ahttpcon_clone::delimit (int *delimit_status)
 	*delimit_status = HTTP_BAD_REQUEST;
 	return NULL;
       }
+  }
+
+  if (request_bytes.size() > maxline) {
+      *delimit_status = HTTP_URI_TOO_BIG;
+      return NULL;
   }
 
   return (NULL);


### PR DESCRIPTION
Sometimes this happens:
1. A small request packet comes in
2. A second (big) request packet comes in. Some of it is URI, the rest is not. `::delimit` sees it and is like "holy shit, this thing is too big" and throws a 414.

This fix only kills the conn if we go over the limit _and_ `::delimit` didn't find a request line.
