### PR TITLE
add optional refresh param for okwstsnow()

### DIFF
--- a/libpub/pubutil.h
+++ b/libpub/pubutil.h
@@ -49,9 +49,9 @@ void got_clock_mode (sfs_clock_t *out, vec<str> s, str lock, bool *errp);
 bool is_safe (const str &s);
 int nfs_safe_stat (const char *f, struct stat *sb);
 inline time_t okwstime () { return sfs_get_timenow(); }
-inline double okwstsnow ()
+inline double okwstsnow (bool refresh = false)
 {
-    timespec ts = sfs_get_tsnow();
+    timespec ts = sfs_get_tsnow(refresh);
     double d = 1000000000;
     return ts.tv_sec + ts.tv_nsec / d;
 }


### PR DESCRIPTION
Sydney added a similar thing for okwsmstime(). This is basically the same function but returns the time in seconds as a double (down to nanosecond accuracy), instead of in ms as an int. Neither are all that useful without ability to force refresh. I believe this param should actually be turned on by default for these, but we might want to verify that it wouldn't slow any existing code down--for now, keeping refresh=false as default
