### PR TITLE
Do not run /pub as part of regtest

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -9,6 +9,9 @@ tameclean:
 	done
 
 test:
-	for dir in system pub; do \
+	for dir in system; do \
 		(cd $$dir && $(MAKE) test ) ; \
 	done
+
+pub_test:
+	cd pub && $(MAKE) test;


### PR DESCRIPTION
old version of automake (such as the one in debian 6) are not able to run those tests properly. This fixes the regtest build target.
