### PR TITLE
always cancel the abuf_t when it's time to stop chunking

### DIFF
--- a/libweb/okwc.h
+++ b/libweb/okwc.h
@@ -206,6 +206,7 @@ private:
 public: 
   okwc_chunker_t (abuf_t *a, ptr<ok::scratch_handle_t> s)
     : async_parser_t (a), http_hdr_t (a, s), sz (0), state (START) {}
+  ~okwc_chunker_t() { cancel(); }
   size_t get_sz () const { return sz; }
   void next_chunk () { sz = 0; state = FINISH_PREV; }
 protected:

--- a/libweb/okwc3.T
+++ b/libweb/okwc3.T
@@ -419,7 +419,6 @@ resp_t::run_chunker_T (evi_t ev)
   do { 
     twait { c->parse (connector::cnc (mkevent (status), ev, &outc)); }
     if (outc == OUTCOME_CANCELLED) {
-      c->cancel ();
       status = CANCELLED_STATUS;
 
     } else if (status == HTTP_OK && (sz = c->get_sz ())) {


### PR DESCRIPTION
This fixes at least one okwc4 crasher.
