### PR TITLE
Documentation for pub functions is now mandatory

### DIFF
--- a/libpub/pub3lib.h
+++ b/libpub/pub3lib.h
@@ -26,6 +26,8 @@ namespace pub3 {
     virtual str name () const { return _name; }
     void set_name (str lib, str n);
 
+    const str* documentation () const override = 0;
+
   protected:
     virtual bool safe_args () const { return true; }
 
@@ -159,74 +161,66 @@ namespace pub3 {
   //
 #define PUB3_DOC_MEMBERS\
   static const str DOCUMENTATION;                                       \
-  virtual const str* documentation () const { return &DOCUMENTATION; };
-#define NO_PUB3_DOC_MEMBERS
+  const str* documentation () const final { return &DOCUMENTATION; };
 
-#define PUB3_COMPILED_FN_FULL(x,pat,__doc)                        \
-  class x##_t : public pub3::patterned_fn_t {                   \
-   public:                                                         \
-   x##_t () : patterned_fn_t (libname, #x, pat) {};               \
-   ptr<const expr_t>                                           \
-    v_eval_2 (eval_t *p, const vec<arg_t> &args) const;			\
-    __doc                                                         \
+#define PUB3_COMPILED_FN(x,pat)                                         \
+  class x##_t : public pub3::patterned_fn_t {                           \
+  public:                                                               \
+   x##_t () : patterned_fn_t (libname, #x, pat) {};                     \
+   ptr<const expr_t>                                                    \
+   v_eval_2 (eval_t *p, const vec<arg_t> &args) const;                  \
+   PUB3_DOC_MEMBERS                                                     \
   }
-#define PUB3_COMPILED_FN(__x,__pat)	PUB3_COMPILED_FN_FULL(__x,__pat,NO_PUB3_DOC_MEMBERS)
-#define PUB3_COMPILED_FN_DOC(__x,__pat)	PUB3_COMPILED_FN_FULL(__x,__pat,PUB3_DOC_MEMBERS)
-  
-#define PUB3_FILTER_FULL(x,__doc)                          \
-  class x##_t : public pub3::patterned_fn_t {		     \
-  public:						     \
-  x##_t () : patterned_fn_t (libname, #x, "s") {}	     \
-  static str filter (str s);				     \
-  ptr<const expr_t>					     \
-  v_eval_2 (eval_t *e, const vec<arg_t> &args) const	     \
+
+#define PUB3_COMPILED_FN_DOC(__x,__pat) PUB3_COMPILED_FN(__x,__pat)
+
+#define PUB3_FILTER(x)                                       \
+  class x##_t : public pub3::patterned_fn_t {                \
+  public:                                                    \
+  x##_t () : patterned_fn_t (libname, #x, "s") {}            \
+  static str filter (str s);                                 \
+  ptr<const expr_t>                                          \
+  v_eval_2 (eval_t *e, const vec<arg_t> &args) const         \
     { return expr_str_t::safe_alloc (filter (args[0]._s)); } \
-  __doc                                                        \
+  PUB3_DOC_MEMBERS                                           \
   }
-#define PUB3_FILTER(__x)	PUB3_FILTER_FULL(__x,NO_PUB3_DOC_MEMBERS)
-#define PUB3_FILTER_DOC(__x)	PUB3_FILTER_FULL(__x,PUB3_DOC_MEMBERS)
 
-#define PUB3_COMPILED_HANDROLLED_FN_FULL(x,__doc)             \
-  class x##_t : public pub3::compiled_fn_t {				\
-  public:								\
-  x##_t () : compiled_fn_t (libname, #x) {}				\
-  ptr<const expr_t> eval_to_val (eval_t *e, args_t args) const;		\
-  void pub_to_val (eval_t *p, args_t args, cxev_t, CLOSURE) const;	\
-  bool count_args (eval_t *p, size_t s) const;			\
-  __doc                                                   \
+#define PUB3_FILTER_DOC(__x) PUB3_FILTER(__x)
+
+#define PUB3_COMPILED_HANDROLLED_FN(x)                                  \
+  class x##_t : public pub3::compiled_fn_t {                            \
+  public:                                                               \
+  x##_t () : compiled_fn_t (libname, #x) {}                             \
+  ptr<const expr_t> eval_to_val (eval_t *e, args_t args) const;         \
+  void pub_to_val (eval_t *p, args_t args, cxev_t, CLOSURE) const;      \
+  bool count_args (eval_t *p, size_t s) const;                          \
+  PUB3_DOC_MEMBERS                                                      \
   }
-#define PUB3_COMPILED_HANDROLLED_FN(__x)	\
-  PUB3_COMPILED_HANDROLLED_FN_FULL(__x,NO_PUB3_DOC_MEMBERS)
-#define PUB3_COMPILED_HANDROLLED_FN_DOC(__x) \
-  PUB3_COMPILED_HANDROLLED_FN_FULL(__x,PUB3_DOC_MEMBERS)
-  
-#define PUB3_COMPILED_UNPATTERNED_FN_FULL(x,__doc)            \
-  class x##_t : public pub3::compiled_fn_t {				\
-  public:								\
-  x##_t () : compiled_fn_t (libname, #x) {}				\
-  ptr<const expr_t>							\
-  v_eval_1 (eval_t *p, const margs_t &args) const;			\
-  __doc                                                       \
+#define PUB3_COMPILED_HANDROLLED_FN_DOC(__x) PUB3_COMPILED_HANDROLLED_FN(__x)
+
+#define PUB3_COMPILED_UNPATTERNED_FN(x)                                 \
+  class x##_t : public pub3::compiled_fn_t {                            \
+  public:                                                               \
+  x##_t () : compiled_fn_t (libname, #x) {}                             \
+  ptr<const expr_t>                                                     \
+  v_eval_1 (eval_t *p, const margs_t &args) const;                      \
+  PUB3_DOC_MEMBERS                                                      \
   }
-#define PUB3_COMPILED_UNPATTERNED_FN(__x)	\
-  PUB3_COMPILED_UNPATTERNED_FN_FULL(__x,NO_PUB3_DOC_MEMBERS)
-#define PUB3_COMPILED_UNPATTERNED_FN_DOC(__x) \
-  PUB3_COMPILED_UNPATTERNED_FN_FULL(__x,PUB3_DOC_MEMBERS)
- 
-  
-#define PUB3_COMPILED_FN_BLOCKING_FULL(x,pat,__doc)               \
-  class x##_t : public pub3::patterned_fn_blocking_t {			\
-  public:								\
-  x##_t () : patterned_fn_blocking_t (libname, #x, pat) {}		\
-  void									\
+
+#define PUB3_COMPILED_UNPATTERNED_FN_DOC(__x) PUB3_COMPILED_UNPATTERNED_FN(__x)
+
+
+#define PUB3_COMPILED_FN_BLOCKING(x,pat)                                \
+  class x##_t : public pub3::patterned_fn_blocking_t {                  \
+  public:                                                               \
+  x##_t () : patterned_fn_blocking_t (libname, #x, pat) {}              \
+  void                                                                  \
   v_pub_to_val_2 (eval_t *, const vec<arg_t> &, cxev_t, CLOSURE) const; \
-  __doc                                                                   \
+  PUB3_DOC_MEMBERS                                                      \
   }
-#define PUB3_COMPILED_FN_BLOCKING(__x,__pat) \
-  PUB3_COMPILED_FN_BLOCKING_FULL(__x,__pat,NO_PUB3_DOC_MEMBERS)
 #define PUB3_COMPILED_FN_BLOCKING_DOC(__x,__pat) \
-  PUB3_COMPILED_FN_BLOCKING_FULL(__x,__pat,PUB3_DOC_MEMBERS)
-  
+  PUB3_COMPILED_FN_BLOCKING(__x,__pat)
+
   //-----------------------------------------------------------------------
 
 };

--- a/libpub/pub3tracer.T
+++ b/libpub/pub3tracer.T
@@ -56,6 +56,11 @@ namespace pub3 {
         ev->trigger();
     }
 
+    const str* serial_shotgun_t::documentation() const {
+        static str doc = "internal function";
+        return &doc;
+    }
+
     tamed void
     serial_shotgun_t::v_pub_to_val_2(eval_t *e, const checked_args_t &args,
                                      cxev_t ev)
@@ -137,6 +142,11 @@ namespace {
 
         ptr<const pub3::expr_t>
         v_eval_2(pub3::eval_t *p, const vec<arg_t> &args) const;
+
+        const str* documentation () const final {
+            static str doc = "internal function";
+            return &doc;
+        };
     };
 
 

--- a/libpub/pub3tracer.h
+++ b/libpub/pub3tracer.h
@@ -43,6 +43,7 @@ namespace pub3 {
         serial_shotgun_t() : patterned_fn_blocking_t("rfn3", "shotgun", "l") {}
         void v_pub_to_val_2(eval_t *, const vec<arg_t> &, cxev_t,
                             CLOSURE) const;
+        const str* documentation () const final;
     };
 
     //--------------------------------------------------------------------------

--- a/librfn/okrfn.h
+++ b/librfn/okrfn.h
@@ -19,8 +19,8 @@ namespace rfn3 {
   // Most of the functions have been moved into okrfn-int.h, so that
   // we can add new functions without having to recompile and relink lib
   // TODO: figure out why we need to expand one level of macro here...
-  PUB3_COMPILED_FN_FULL(warn, "s",PUB3_DOC_MEMBERS);
-  PUB3_COMPILED_FN_FULL(replace, "srO|b",PUB3_DOC_MEMBERS);
+  PUB3_COMPILED_FN(warn, "s");
+  PUB3_COMPILED_FN(replace, "srO|b");
   
   //-----------------------------------------------------------------------
 

--- a/pub/pub3trace_replayer.T
+++ b/pub/pub3trace_replayer.T
@@ -305,6 +305,11 @@ namespace {
         v_eval_2(pub3::eval_t *, const vec<arg_t> &) const {
             FATAL("Someone called fork...");
         }
+
+        const str* documentation () const final {
+            static str doc = "internal function";
+            return &doc;
+        };
     };
 
     //--------------------------------------------------------------------------

--- a/test/system/okclib.C
+++ b/test/system/okclib.C
@@ -57,6 +57,8 @@ namespace okclib {
     return expr_str_t::alloc (s);
   }
 
+  const str money_t::DOCUMENTATION = R"(internal function)";
+
   //-----------------------------------------------------------------------
 
   ptr<const expr_t>
@@ -75,6 +77,7 @@ namespace okclib {
     return expr_str_t::alloc (b);
   }
 
+  const str commafy_t::DOCUMENTATION = R"(internal function)";
   //-------------------------------------------------------------------
   
   ptr<const expr_t>
@@ -91,7 +94,9 @@ namespace okclib {
     }
     return out;
   }
-  
+
+  const str bit_set_t::DOCUMENTATION = R"(internal function)";
+
   //-----------------------------------------------------------------------
   
   const char *libname = "okclib";


### PR DESCRIPTION
Now that everything is documented we flip the switch by making the `documentation` function a pure virtual function....
