### PR TITLE
xmlrpcc: detemplatize

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,9 +1,9 @@
 
-SUBDIRS = system regtest unit pub bson
+SUBDIRS = system regtest unit pub
 .PHONY: test tameclean
 
 tameclean:
-	for dir in system unit bson; do \
+	for dir in system unit; do \
 		(cd $$dir && $(MAKE) tameclean ) ; \
 	done
 

--- a/xmlrpcc/Makefile.am
+++ b/xmlrpcc/Makefile.am
@@ -9,7 +9,7 @@ okwsbin_PROGRAMS = xmlrpcc
 
 noinst_HEADERS = rpcc.h parse.h
 
-xmlrpcc_SOURCES = genheader.C gencfile.C parse.yy scan.ll rpcc.C 
+xmlrpcc_SOURCES = genheader.C gencfile.C gentrav.C parse.yy scan.ll rpcc.C
 xmlrpcc_LDADD = $(LDADD)
 xmlrpcc_DEPENDENCIES = $(LIBASYNC)
 

--- a/xmlrpcc/gencfile.C
+++ b/xmlrpcc/gencfile.C
@@ -33,8 +33,8 @@ mkmshl_xml (str id)
   aout << "bool\n"
        << "xml_" << id << " (" << XML_OBJ << " *xml, void *objp)\n"
        << "{\n"
-       << "  return xml_rpc_traverse (xml, *static_cast<" 
-       << id << " *> (objp), NULL);\n"
+       << "  return xml_rpc_traverse (xml, *static_cast<" << id
+       << " *> (objp), nullptr);\n"
        << "}\n"
        << "\n";
 }
@@ -174,15 +174,15 @@ dumpstructmember_xml(str swval, const rpc_decl *rd)
   if (swval)
     aout << "  { \"" << swval << "\", ";
   else
-    aout << "  { NULL, ";
+    aout << "  { nullptr, ";
   if (rd->id)
     aout << "\"" << rd->id << "\", ";
   else
-    aout << "NULL, ";
+    aout << "nullptr, ";
   if (rd->type)
     aout << "&xml_typeinfo_" << rd->type << ", ";
   else
-    aout << "NULL, ";
+    aout << "nullptr, ";
   aout << (int)rd->qual << ", "
        << (rd->bound ? rd->bound : "0") << " }";
 }
@@ -205,10 +205,10 @@ dumpstruct_xml (const rpc_sym *s)
 
  aout << "static xml_struct_entry_t _xml_contents_" << rs->id << "[] = {\n";
   for (rd = rs->decls.base (); rd < rs->decls.lim (); rd++) {
-    dumpstructmember_xml(NULL, rd);
+    dumpstructmember_xml(nullptr, rd);
     aout << ",\n";
   }
-  aout << "  { NULL, NULL, NULL, 0, 0 }\n";
+  aout << "  { nullptr, nullptr, nullptr, 0, 0 }\n";
   aout << "};\n\n";
 
   aout << "xml_typeinfo_t xml_typeinfo_" << rs->id << " = {\n"
@@ -258,13 +258,13 @@ dumpunion_xml (const rpc_sym *s)
        << "}\n\n";
 
   aout << "xml_struct_entry_t _xml_contents_" << rs->id << "[] = {\n"
-       << "  { NULL, \"" << rs->tagid << "\", &xml_typeinfo_" 
-       << rs->tagtype << ", 0, 0},\n";
+       << "  { nullptr, \"" << rs->tagid << "\", &xml_typeinfo_" << rs->tagtype
+       << ", 0, 0},\n";
   for (const rpc_utag *rc = rs->cases.base(); rc < rs->cases.lim(); rc++) {
     dumpstructmember_xml(rc->swval, &rc->tag);
     aout << ",\n";
   }
-  aout << "  { NULL, NULL, NULL, 0, 0 }," 
+  aout << "  { nullptr, nullptr, nullptr, 0, 0 },"
        << "};\n\n";
 
   aout << "xml_typeinfo_t xml_typeinfo_" << rs->id << " = {\n"
@@ -292,7 +292,7 @@ dumpenum_xml (const rpc_sym *s)
   aout << "xml_typeinfo_t xml_typeinfo_" << rs->id << " = {\n"
        << "  \"" << rs->id << "\",\n"
        << "  xml_typeinfo_t::ENUM,\n"
-       << "  NULL\n"
+       << "  nullptr\n"
        << "};\n\n";
 
   type_tab.push_back(rs->id);
@@ -450,7 +450,7 @@ dumptypedef_xml (const rpc_sym *s)
   if (skip_xml) return;
   const rpc_decl *rd = s->stypedef.addr ();
   aout << "static xml_struct_entry_t _xml_typedef_" << rd->id << " = \n";
-  dumpstructmember_xml(NULL, rd);
+  dumpstructmember_xml(nullptr, rd);
   aout << ";\n\n";
   aout << "xml_typeinfo_t xml_typeinfo_" << rd->id << " = {\n"
        << "  \"" << rd->id << "\",\n"
@@ -540,24 +540,23 @@ print_enum (const rpc_enum *s)
       "  case " << cp->id << ":\n"
       "    p = \"" << cp->id << "\";\n"
       "    break;\n";
-  aout <<
-    "  default:\n"
-    "    p = NULL;\n"
-    "    break;\n"
-    "  }\n"
-    "  if (name) {\n"
-    "    if (prefix)\n"
-    "      sb << prefix;\n"
-    "    sb << \"" << s->id << " \" << name << \" = \";\n"
-    "  };\n"
-    "  if (p)\n"
-    "    sb << p;\n"
-    "  else\n"
-    "    sb << int (obj);\n"
-    "  if (prefix)\n"
-    "    sb << \";\\n\";\n"
-    "  return sb;\n"
-    "};\n";
+  aout << "  default:\n"
+          "    p = nullptr;\n"
+          "    break;\n"
+          "  }\n"
+          "  if (name) {\n"
+          "    if (prefix)\n"
+          "      sb << prefix;\n"
+          "    sb << \"" << s->id << " \" << name << \" = \";\n"
+                                     "  };\n"
+                                     "  if (p)\n"
+                                     "    sb << p;\n"
+                                     "  else\n"
+                                     "    sb << int (obj);\n"
+                                     "  if (prefix)\n"
+                                     "    sb << \";\\n\";\n"
+                                     "  return sb;\n"
+                                     "};\n";
   print_print (s->id);
 }
 
@@ -587,13 +586,12 @@ print_struct (const rpc_struct *s)
     "  }\n";
 
   if (num > 1) {
-    aout <<
-      "  const char *sep = NULL;\n"
-      "  if (prefix) {\n"
-      "    sep = \"\";\n"
-      "  } else {\n"
-      "    sep = \", \";\n"
-      "  }\n" ;
+    aout << "  const char *sep = nullptr;\n"
+            "  if (prefix) {\n"
+            "    sep = \"\";\n"
+            "  } else {\n"
+            "    sep = \", \";\n"
+            "  }\n";
   }
 
   if (dp < ep)
@@ -722,7 +720,7 @@ dump_const_table (str fname)
   for (size_t i = 0; i < const_tab.size (); i++) {
     aout << "  { \"" << const_tab[i] << "\", " << const_tab[i]  << " },\n";
   }
-  aout << "  { NULL, 0 }\n";
+  aout << "  { nullptr, 0 }\n";
   aout << "};\n\n";
 }
 
@@ -733,7 +731,7 @@ dump_prog_table (str fname)
   for (size_t i = 0; i < prog_tab.size (); i++) {
     aout << "  &" << prog_tab[i] << ",\n";
   }
-  aout << "  NULL\n"
+  aout << "  nullptr\n"
        << "};\n\n";
 }
 
@@ -744,7 +742,7 @@ dump_type_table (str fname)
   for (size_t i = 0; i < type_tab.size (); i++) {
     aout << "  &xml_typeinfo_" << type_tab[i] << ",\n";
   }
-  aout << "  NULL\n"
+  aout << "  nullptr\n"
        << "};\n\n";
 }
 
@@ -771,25 +769,24 @@ gencfile (str fname)
   aout << "#include \"" << makehdrname (fname) << "\"\n"
        << "#include \"xdrsnappy.h\"\n\n";
 
-#if 0
-  for (const rpc_sym *s = symlist.base (); s < symlist.lim (); s++)
-    if (s->type == rpc_sym::PROGRAM)
-      for (const rpc_vers *rv = s->sprogram->vers.base ();
-	   rv < s->sprogram->vers.lim (); rv++)
-	for (const rpc_proc *rp = rv->procs.base ();
-	     rp < rv->procs.lim (); rp++) {
-	  needtype.insert (rp->arg);
-	  needtype.insert (rp->res);
-	}
-#endif
-
   aout << "#ifdef MAINTAINER\n\n";
   for (const rpc_sym *s = symlist.base (); s < symlist.lim (); s++)
     dumpprint (s);
   aout << "#endif /* MAINTAINER*/\n";
 
-  for (const rpc_sym *s = symlist.base (); s < symlist.lim (); s++)
+  for (const rpc_sym *s = symlist.base(); s < symlist.lim(); s++) {
     dumpsym (s);
+    if (template_specialisations.size() != 0) {
+      const str fn_name = gen_rpc_trav(s, false);
+      if (fn_name)
+        for (str tp : template_specialisations) {
+          aout << "bool rpc_traverse(" << tp << " t, " << getid(s) << "& v, "
+               << "const char* fld){\n"
+               << "    return " << fn_name << "<" << tp << ">(t, v, fld);\n"
+               << "}\n\n";
+        }
+    }
+  }
 
   aout << "\n";
 

--- a/xmlrpcc/gentrav.C
+++ b/xmlrpcc/gentrav.C
@@ -1,0 +1,158 @@
+#include "rpcc.h"
+
+str getid(const rpc_sym *s) {
+  switch (s->type) {
+    case rpc_sym::CONST:
+      return s->sconst->id;
+    case rpc_sym::STRUCT:
+      return s->sstruct->id;
+    case rpc_sym::UNION:
+      return s->sunion->id;
+    case rpc_sym::ENUM:
+      return s->senum->id;
+    case rpc_sym::TYPEDEF:
+      return s->stypedef->id;
+    case rpc_sym::PROGRAM:
+      return s->sprogram->id;
+    case rpc_sym::NAMESPACE:
+      return s->snamespace->id;
+    case rpc_sym::LITERAL:
+      return nullptr;
+  }
+}
+
+vec<str> template_specialisations{"ptr<v_XDR_t>", "XDR*"};
+
+static str get_trav_name(const rpc_sym *s, bool inl) {
+  if (inl) {
+    return "rpc_traverse";
+  }
+  return str(strbuf("rpc_traverse_") << getid(s));
+}
+
+static str dump_rpc_trav_struct(const rpc_sym *s, bool inl) {
+  const rpc_struct *rs = s->sstruct.addr();
+  const char *field = inl ? rpc_field : "const char* field";
+  const str fn_name = get_trav_name(s, inl);
+
+  aout << "template<class T> " << (rs->decls.size() > 1 ? "" : "inline ")
+       << "bool\n" << fn_name << " (T &t, " << rs->id << " &obj, " << field
+       << ")\n"
+       << "{\n"
+       << "  bool ret = true;\n"
+       << "  rpc_enter_field (t, field);\n";
+
+  const rpc_decl *rd = rs->decls.base();
+  if (rd < rs->decls.lim()) {
+    aout << "  ret = rpc_traverse (t, obj." << rd->id << ", \"" << rd->id
+         << "\")";
+    rd++;
+    for (; rd < rs->decls.lim(); rd++) {
+      aout << "\n    && rpc_traverse (t, obj." << rd->id << ", \"" << rd->id
+           << "\")";
+    }
+    aout << ";\n";
+  }
+  aout << "  rpc_exit_field (t, field);\n"
+       << "  return ret;\n"
+       << "}\n\n";
+  return fn_name;
+}
+
+static void punionmacro(str prefix, const rpc_union *rs, const rpc_utag *rt) {
+  if (rt->tag.type == "void")
+    aout << prefix << "voidaction; \\\n";
+  else
+    aout << prefix << "action (" << rt->tag.type << ", " << rt->tag.id
+         << "); \\\n";
+  aout << prefix << "break; \\\n";
+}
+
+static void punionmacrodefault(str prefix, const rpc_union *rs) {
+  aout << prefix << "defaction; \\\n";
+  aout << prefix << "break; \\\n";
+}
+
+static str dump_rpc_trav_union(const rpc_sym *s, bool inl) {
+  const rpc_union *rs = s->sunion.addr();
+  const char *field = inl ? rpc_field : "const char* field";
+  const str fn_name = get_trav_name(s, inl);
+  const str inl_inst = inl ? "inline " : "";
+  aout << "#define rpcunion_tag_" << rs->id << " " << rs->tagid << "\n";
+  aout << "#define rpcunion_switch_" << rs->id
+       << "(swarg, action, voidaction, defaction) \\\n";
+  pswitch("  ", rs, "swarg", punionmacro, " \\\n", punionmacrodefault);
+
+  aout << "\n";
+
+  aout << inl_inst << "void " << rs->id << "::set_" << rs->tagid
+       << " (" << rs->tagtype << " _tag) {\n"
+       << "    const_cast<" << rs->tagtype << " &> (" << rs->tagid
+       << ") = _tag;\n"
+       << "    rpcunion_switch_" << rs->id << "\n"
+       << "      (_tag, RPCUNION_SET, _base.destroy (), _base.destroy ());\n"
+       << "  }\n";
+
+  aout << "template<class T> bool\n" << fn_name << " (T &t, " << rs->id
+       << " &obj, " << field << ")\n"
+       << "{\n"
+       << "  bool ret = true;\n"
+       << "  rpc_enter_field (t, field);\n"
+       << "  " << rs->tagtype << " tag = obj." << rs->tagid << ";\n"
+       << "  if (!rpc_traverse (t, tag, \"" << rs->tagid << "\")) { \n"
+       << "    ret = false;\n"
+       << "  } else {\n"
+       << "    if (tag != obj." << rs->tagid << ")\n"
+       << "      obj.set_" << rs->tagid << " (tag);\n\n"
+       << "    rpcunion_switch_" << rs->id << "\n"
+       << "      (obj." << rs->tagid << ", ret = RPCUNION_TRAVERSE_2, "
+       << "ret = true, ret = false);\n"
+       << "    /* gcc 4.0.3 makes buggy warnings without the following.. */\n"
+       << "  }\n"
+       << "  rpc_exit_field (t, field);\n"
+       << "  return ret;\n"
+       << "}\n\n";
+
+  aout << "#undef rpcunion_tag_" << rs->id << "\n";
+  aout << "#undef rpcunion_switch_" << rs->id << "\n\n";
+
+  return fn_name;
+}
+
+static str dump_rpc_trav_enum(const rpc_sym *s, bool inl) {
+  const rpc_enum *rs = s->senum.addr();
+  const char *field = inl ? rpc_field : "const char* field";
+  const str fn_name = get_trav_name(s, inl);
+  aout << "\ntemplate<class T> inline bool\n" << fn_name << " (T &t, " << rs->id
+       << " &obj, " << field << ")\n"
+       << "{\n"
+       << "  u_int32_t val = obj;\n"
+       << "  bool ret = true;\n"
+       << "  rpc_enter_field (t, field);\n"
+       << "  if (!rpc_traverse (t, val)) {\n"
+       << "    ret = false;\n"
+       << "  } else {\n"
+       << "    obj = " << rs->id << " (val);\n"
+       << "  }\n"
+       << "  rpc_exit_field (t, field);\n"
+       << "  return ret;\n"
+       << "}\n\n";
+  return fn_name;
+}
+
+str gen_rpc_trav(const rpc_sym *s, bool inl) {
+  switch (s->type) {
+    case rpc_sym::STRUCT:
+      return dump_rpc_trav_struct(s, inl);
+    case rpc_sym::UNION:
+      return dump_rpc_trav_union(s, inl);
+    case rpc_sym::ENUM:
+      return dump_rpc_trav_enum(s, inl);
+    case rpc_sym::TYPEDEF:
+    case rpc_sym::PROGRAM:
+    case rpc_sym::NAMESPACE:
+    case rpc_sym::LITERAL:
+    case rpc_sym::CONST:
+      return nullptr;
+  }
+}

--- a/xmlrpcc/rpcc.h
+++ b/xmlrpcc/rpcc.h
@@ -223,10 +223,15 @@ extern symlist_t symlist;
 
 typedef vec<str> strlist_t;
 extern strlist_t litq;
+extern vec<str> template_specialisations;
 
 str rpcprog (const rpc_program *, const rpc_vers *);
 void genheader (str);
 void gencfile (str);
+str gen_rpc_trav(const rpc_sym *s, bool inl);
+str getid(const rpc_sym *s);
+
+#define rpc_field "const char *field = nullptr"
 
 void pswitch (str prefix, const rpc_union *rs, str swarg,
 	      void (*pt) (str, const rpc_union *rs, const rpc_utag *),


### PR DESCRIPTION
This moves the templated version of rpc_traverse out of the .h file and into the .c files. It provides a significant compile speed boost to our tree and brings all the files under the 30sec compile time target.