### PR TITLE
fix an assertion error in zstr

### DIFF
--- a/libpub/zstr.h
+++ b/libpub/zstr.h
@@ -321,7 +321,7 @@ zbuf::cat (const str &s, bool cp)
     if (z) {
       push_zstr (*z);
     } else {
-      push_str2zstr (s, false);
+      push_str2zstr (s, true);
     }
   }
   return (*this);


### PR DESCRIPTION
This should fix the assertion error we've been seeing in `ztab...`. Not quite sure why have the `lkp` argument at all since setting it to `false` seems to only lead to assertion errors on a race condition (we will error out if a value is still in a globally shared cache instead of using that value).