### PR TITLE
ztab_cache: remove an assertion failure when the same content is adde…

### DIFF
--- a/libpub/zstr.C
+++ b/libpub/zstr.C
@@ -229,7 +229,9 @@ ztab_cache_t::insert (zstr *z)
 {
   tot += z->len ();
   assert (tot <= maxtot);
-  assert (!tab[*z]);
+  if (!tab[*z]) {
+      return;
+  }
   tab.insert (z);
   q.insert_tail (z);
 }


### PR DESCRIPTION
The bug can be seen:

```.c++

#include "zstr.h"
#include <cstring>

int main() {
    zinit();
    zbuf test;
    // We need to add string that are longer than ok_gzip_smallstr
    char cbuf[1024], cbuf2[1024];
    size_t l = 513;
    memset(cbuf, '-', l);
    cbuf[l] = '\000';
    memcpy(cbuf2, cbuf, l + 1);

    test.cat(cbuf, l);
    test.cat(cbuf2, l);

    return 0;
}
```