### PR TITLE
Put a guard around ssl->s3 before setting this flag

### DIFF
--- a/ssld/okssld.T
+++ b/ssld/okssld.T
@@ -523,7 +523,7 @@ namespace okssl {
       ssl_to_std_proxy_t* prx = static_cast<ssl_to_std_proxy_t*> 
 	SSL_get_app_data(ssl);
       if (prx && !prx->allow_cli_renog())
-	ssl->s3->flags |= SSL3_FLAGS_NO_RENEGOTIATE_CIPHERS;
+	if (ssl->s3) ssl->s3->flags |= SSL3_FLAGS_NO_RENEGOTIATE_CIPHERS;
     }
   }
 


### PR DESCRIPTION
This should stop crashes from occurring when `allow_cli_renog` and `ssl3` are both disabled but a proxy exists.