### PR TITLE
wrong way

### DIFF
--- a/libpub/pub3ast.T
+++ b/libpub/pub3ast.T
@@ -9,7 +9,7 @@ namespace pub3 {
   //============================================ identifier_list_t =========
 
     void identifier_list_t::push_back(str s, bool opt) {
-        if (opt) {
+        if (!opt) {
             _params.push_back(s);
         } else {
             _opt_params.push_back(s);


### PR DESCRIPTION
@tejacques here is the fix!

This nature of this fix may make things look like they could have never possibly worked, but interesting enough they did work as long as you used  "remote" publisher. The reason is because the XDR functions for `identifier_list_t` undid the bug in `push_back`. This made web servers work, but anything that used a local publisher not work. I would test this pretty thoroughly before putting live.